### PR TITLE
feat: Enhance Monaco editor model and improve types

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "scripts": {
     "clean": "rimraf ./app/scripts",
+    "predev": "npm run clean",
     "prebuild": "npm run clean",
     "prepublish": "npm run build",
     "build": "webpack --mode production",

--- a/src/content-script-tools/text-syncer.ts
+++ b/src/content-script-tools/text-syncer.ts
@@ -1,4 +1,10 @@
-import type { IHandler, Options, UpdateTextPayload } from '@/handlers/types';
+import {
+  IHandler,
+  Options,
+  UpdateTextPayload,
+  RegisterPayload,
+  SocketPostPayloadMap,
+} from '@/handlers/types';
 
 const NORMAL_CLOSE_CODE = 1000;
 
@@ -69,7 +75,7 @@ class TextSyncer {
   makeTextChangeListener(port: chrome.runtime.Port, handler: IHandler) {
     return () => {
       handler.getValue().then((text: string) => {
-        this.post(port, 'updateText', { text: text });
+        this.post(port, 'updateText', { text });
       });
     };
   }
@@ -89,9 +95,13 @@ class TextSyncer {
     options?: Options,
   ) {
     options = options || {};
-
     handler.getValue().then((text: string) => {
-      const payload: any = { url: url, title: title, text: text };
+      const payload: RegisterPayload = {
+        ...options,
+        url: url,
+        title: title,
+        text: text,
+      };
 
       let extension = options?.extension;
 
@@ -113,8 +123,12 @@ class TextSyncer {
    * @param type - The type of the message.
    * @param payload - The payload of the message.
    */
-  post(port: chrome.runtime.Port, type: string, payload: any) {
-    return port.postMessage({ type: type, payload: payload });
+  post<T extends keyof SocketPostPayloadMap>(
+    port: chrome.runtime.Port,
+    type: T,
+    payload: SocketPostPayloadMap[T],
+  ) {
+    return port.postMessage({ type, payload });
   }
 }
 

--- a/src/handlers/base.ts
+++ b/src/handlers/base.ts
@@ -3,6 +3,7 @@ import {
   IHandler,
   IContentEventsBinder,
   UpdateTextPayload,
+  Options,
 } from '@/handlers/types';
 
 /**
@@ -32,8 +33,8 @@ export default class BaseHandler extends EventEmitter implements IHandler {
   /**
    * Handler initialization or data loading.
    */
-  load(): Promise<void> {
-    return Promise.resolve();
+  load(): Promise<Options> {
+    return Promise.resolve({});
   }
 
   /**

--- a/src/handlers/types.ts
+++ b/src/handlers/types.ts
@@ -1,16 +1,19 @@
+export interface IPosition {
+  lineNumber?: number;
+  column?: number;
+}
+
 /**
  * Defines options for setting value.
  */
-export interface UpdateTextPayload {
-  lineNumber?: number;
-  column?: number;
+export interface UpdateTextPayload extends IPosition {
   text: string;
 }
 /**
  * Defines options for handler configuration.
  */
-export interface Options {
-  extension?: string | string[];
+export interface Options extends IPosition {
+  extension?: string | string[] | null;
 }
 
 /**
@@ -20,7 +23,7 @@ export interface IHandler {
   /**
    * Loads data or performs an initialization operation.
    */
-  load(): Promise<void>;
+  load(): Promise<Options>;
 
   /**
    * Sets a value with optional settings.
@@ -75,3 +78,27 @@ export interface IContentEventsBinder {
    */
   bind(context: IHandler, window: Window): void;
 }
+
+export type PostToInjectorPayloadMap = {
+  ready: Options;
+  value: UpdateTextPayload;
+  change: {};
+};
+
+export type BaseInjectedPostType = keyof PostToInjectorPayloadMap;
+
+export interface RegisterPayload extends UpdateTextPayload, Options {
+  url: string;
+  title: string;
+}
+
+export type SocketPostPayloadMap = {
+  register: RegisterPayload;
+  updateText: UpdateTextPayload;
+};
+
+export type PostToInjectedPayloadMap = {
+  initialize: { name: string };
+  setValue: UpdateTextPayload;
+  getValue: undefined;
+};


### PR DESCRIPTION
- Import `IDisposable` from `monaco-editor` for managing event listeners
- Add detailed documentation for class properties
- Implement `getPosition` method to get the current cursor position
- Implement `bindChange` and `unbindChange` methods for attaching and
  detaching content change listeners
- Refactor `setValue` method to support silent execution and cursor
  positioning
- Improve method documentation for clarity and readability
- Expand imports in `text-syncer.ts`, `base.ts`, `injected/base.ts`, and
  `injector.ts` to include new types for better type safety and clarity.
- Refactor `TextSyncer` class to use destructuring and concise property
  names in object literals.
- Update `BaseHandler`'s `load` method to return `Promise<Options>` instead
  of `Promise<void>`, aligning with new expected return type.
- Enhance `BaseInjectedHandler` and `InjectorHandler` to utilize specific
  payload types for messaging, improving type checking and reducing the
  risk of runtime errors.
- Introduce `IPosition` interface in `types.ts` to consolidate position
  related properties, and extend this in `UpdateTextPayload` and `Options`.
- Define `PostToInjectorPayloadMap`, `BaseInjectedPostType`,
  `RegisterPayload`, `SocketPostPayloadMap`, and
  `PostToInjectedPayloadMap` to tightly couple message types with their
  payloads, ensuring that the correct data is passed and handled across
  different parts of the system.
- Added a new script "predev" to run the clean task before development starts